### PR TITLE
Todo List API에 테스트 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+
     // Use JUnit Jupiter API for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
 

--- a/app/src/main/java/com/codesoom/assignment/App.java
+++ b/app/src/main/java/com/codesoom/assignment/App.java
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class App {
     public String getGreeting() {
-        return "Hello, world!";
+        return "Hello, world!!";
     }
 
     public static void main(String[] args) {

--- a/app/src/main/java/com/codesoom/assignment/models/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/models/Task.java
@@ -8,6 +8,10 @@ public class Task {
     public Task() {
     }
 
+    public Task(String title) {
+        this.title = title;
+    }
+
     public Task(Long id, String title) {
         this.id = id;
         this.title = title;

--- a/app/src/main/java/com/codesoom/assignment/models/Task.java
+++ b/app/src/main/java/com/codesoom/assignment/models/Task.java
@@ -5,6 +5,14 @@ public class Task {
 
     private String title;
 
+    public Task() {
+    }
+
+    public Task(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
     public Long getId() {
         return id;
     }

--- a/app/src/test/java/com/codesoom/assignment/AppTest.java
+++ b/app/src/test/java/com/codesoom/assignment/AppTest.java
@@ -1,0 +1,14 @@
+package com.codesoom.assignment;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppTest {
+    @Test
+    void appHasAGreeting() {
+        App classUnderTest = new App();
+        String result = classUnderTest.getGreeting();
+        assertThat(result).isEqualTo("Hello, world!!");
+    }
+}

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,13 +56,12 @@ class TaskServiceTest {
         }
 
         @Test
-        @DisplayName("반환한 Task의 title과 매개변수로 전달한 Task의 title은 동일하다")
-        void it_returns_task_having_title_equal_to_default_task_title() {
-            final Task task = new Task();
-            task.setTitle(TASK_TITLE_UPDATED);
+        @DisplayName("매개변수로 전달한 값이 모두 반영되어 생성된 Task를 반환한다")
+        void it_returns_task_reflecting_params() {
+            final Task task = new Task(TASK_TITLE_UPDATED);
 
-            final String actual = service.createTask(task).getTitle();
-            assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
+            final Task actual = service.createTask(task);
+            assertThat(actual.getTitle()).isEqualTo(TASK_TITLE_UPDATED);
         }
     }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -87,40 +87,38 @@ class TaskServiceTest {
     @Nested
     @DisplayName("updateTask 메소드는")
     class Describe_updateTask {
-        @Nested
-        @DisplayName("만약 존재하는 Task를 수정한다면")
-        class Context_with_existing_task {
-            Task subject() {
-                final Task task = new Task(TASK_TITLE_UPDATED);
+        abstract class ContextUpdating {
+            final Task task = new Task(TASK_TITLE_UPDATED);
+            Task givenExistingTask(){
                 return service.updateTask(TASK_ID, task);
             }
-
+            void givenNotExistingTask(){
+                service.updateTask(TASK_ID_NOT_EXISTING, task);
+            }
+        }
+        @Nested
+        @DisplayName("만약 존재하는 Task를 수정한다면")
+        class Context_with_existing_task extends ContextUpdating {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                final Task actual = subject();
-
-                assertThat(actual.getId()).isEqualTo(TASK_ID);
+                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
             }
 
             @Test
             @DisplayName("매개변수로 전달한 값이 반영된 Task를 반환한다")
             void it_returns_task_reflecting_params() {
-                final Task actual = subject();
-
-                assertThat(actual.getTitle()).isEqualTo(TASK_TITLE_UPDATED);
+                assertThat(givenExistingTask().getTitle()).isEqualTo(TASK_TITLE_UPDATED);
             }
         }
 
         @Nested
         @DisplayName("만약 존재하지 않는 Task를 수정한다면")
-        class Context_with_not_existing_task {
+        class Context_with_not_existing_task extends ContextUpdating {
             @Test
             @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                final Task task = new Task(TASK_TITLE_UPDATED);
-
-                assertThatThrownBy(() -> service.updateTask(TASK_ID_NOT_EXISTING, task))
+                assertThatThrownBy(this::givenNotExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -66,6 +66,7 @@ class TaskServiceTest {
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
                 final Task actual = service.getTask(TASK_ID);
+
                 assertThat(actual.getId()).isEqualTo(TASK_ID);
             }
         }
@@ -92,21 +93,19 @@ class TaskServiceTest {
             @Test
             @DisplayName("Task를 반환하는데, 반환한 Task의 id와 기본 생성된 Task의 id는 동일하다")
             void it_returns_task_having_id_equal_to_default_task_id() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
+                final Task task = new Task(TASK_TITLE_UPDATED);
 
-                final Long actual = service.updateTask(TASK_ID, task).getId();
-                assertThat(actual).isEqualTo(TASK_ID);
+                final Task actual = service.updateTask(TASK_ID, task);
+                assertThat(actual.getId()).isEqualTo(TASK_ID);
             }
 
             @Test
             @DisplayName("Task를 반환하는데, 반환한 Task의 title과 요청 시 전달한 Task의 title과 동일한다")
             void it_returns_task_having_title_equal_to_task_title_delivered() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
+                final Task task = new Task(TASK_TITLE_UPDATED);
 
-                final String actual = service.updateTask(TASK_ID, task).getTitle();
-                assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
+                final Task actual = service.updateTask(TASK_ID, task);
+                assertThat(actual.getTitle()).isEqualTo(TASK_TITLE_UPDATED);
             }
         }
 
@@ -116,8 +115,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("TaskNotFoundException을 발생시킨다")
             void it_throws_exception() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
+                final Task task = new Task(TASK_TITLE_UPDATED);
 
                 assertThatThrownBy(() -> service.updateTask(TASK_ID_NOT_EXISTING, task))
                         .isInstanceOf(TaskNotFoundException.class);

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -35,7 +35,7 @@ class TaskServiceTest {
     @DisplayName("getTasks 메소드는")
     class Describe_getTasks {
         @Test
-        @DisplayName("Collection 타입의 형태로 값을 반환한다")
+        @DisplayName("Collection 타입으로 값을 반환한다")
         void it_returns_list() {
             final List<Task> actual = service.getTasks();
 
@@ -90,21 +90,24 @@ class TaskServiceTest {
         @Nested
         @DisplayName("만약 존재하는 Task를 수정한다면")
         class Context_with_existing_task {
+            Task subject() {
+                final Task task = new Task(TASK_TITLE_UPDATED);
+                return service.updateTask(TASK_ID, task);
+            }
+
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                final Task task = new Task(TASK_TITLE_UPDATED);
+                final Task actual = subject();
 
-                final Task actual = service.updateTask(TASK_ID, task);
                 assertThat(actual.getId()).isEqualTo(TASK_ID);
             }
 
             @Test
             @DisplayName("매개변수로 전달한 값이 반영된 Task를 반환한다")
             void it_returns_task_reflecting_params() {
-                final Task task = new Task(TASK_TITLE_UPDATED);
+                final Task actual = subject();
 
-                final Task actual = service.updateTask(TASK_ID, task);
                 assertThat(actual.getTitle()).isEqualTo(TASK_TITLE_UPDATED);
             }
         }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -69,13 +69,13 @@ class TaskServiceTest {
     @DisplayName("getTask 메소드는")
     class Describe_getTask {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 조회한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 상세조회한다면")
+        class Context_with_existing_task {
             @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 id와 기본 생성된 Task의 id는 동일하다")
-            void it_returns_task_having_id_equal_to_default_task_id() {
-                final Long actual = service.getTask(TASK_ID).getId();
-                assertThat(actual).isEqualTo(TASK_ID);
+            @DisplayName("매개변수로 전달한 id와 동일한 id를 가지고 있는 Task를 반환한다")
+            void it_returns_task_having_id_equal_to_param() {
+                final Task actual = service.getTask(TASK_ID);
+                assertThat(actual.getId()).isEqualTo(TASK_ID);
             }
 
             @Test

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -45,6 +45,46 @@ class TaskServiceTest {
     }
 
     @Nested
+    @DisplayName("createTasks 메소드는")
+    class Describe_createTasks {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task가 1개만 존재한다면")
+        class Context_with_default_task {
+            @Test
+            @DisplayName("Task를 생성하여 Task의 개수가 총 2개가 된다")
+            void it_makes_2_size_of_Collection() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                service.createTask(task);
+                final int actual = service.getTasks().size();
+                assertThat(actual).isEqualTo(TASKS_SIZE + 1);
+            }
+
+            @Test
+            @DisplayName("Task를 반환하는데, 반환한 Task의 id는 Null이 아니다")
+            void it_returns_id_not_null() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                final Long actual = service.createTask(task).getId();
+                assertThat(actual).isNotNull();
+            }
+
+            @Test
+            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 새로 생성한 Task의 title은 동일하다")
+            void it_returns_task_having_title_equal_to_default_task_title() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                final String actual = service.createTask(task).getTitle();
+                assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
+            }
+
+        }
+    }
+
+    @Nested
     @DisplayName("getTask 메소드는")
     class Describe_getTask {
         @Nested

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -24,11 +24,8 @@ class TaskServiceTest {
 
     @BeforeEach
     void setUp() {
-        final Task task = new Task();
-        task.setTitle(TASK_TITLE);
-
         service = new TaskService();
-        service.createTask(task);
+        service.createTask(new Task(TASK_TITLE));
     }
 
     @Nested

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,11 +56,11 @@ class TaskServiceTest {
     @DisplayName("getTask 메소드는")
     class Describe_getTask {
         abstract class ContextGetting {
-            Task givenExistingTask() {
+            Task withExistingTask() {
                 return service.getTask(TASK_ID);
             }
 
-            void givenNotExistingTask() {
+            void withoutNotExistingTask() {
                 service.getTask(TASK_ID_NOT_EXISTING);
             }
         }
@@ -72,7 +71,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
+                assertThat(withExistingTask().getId()).isEqualTo(TASK_ID);
             }
         }
 
@@ -82,7 +81,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("TaskNotFoundException을 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(this::givenNotExistingTask)
+                assertThatThrownBy(this::withoutNotExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 
@@ -95,11 +94,11 @@ class TaskServiceTest {
         abstract class ContextUpdating {
             final Task task = new Task(TASK_TITLE_UPDATED);
 
-            Task givenExistingTask() {
+            Task withExistingTask() {
                 return service.updateTask(TASK_ID, task);
             }
 
-            void givenNotExistingTask() {
+            void withoutExistingTask() {
                 service.updateTask(TASK_ID_NOT_EXISTING, task);
             }
         }
@@ -110,13 +109,13 @@ class TaskServiceTest {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
+                assertThat(withExistingTask().getId()).isEqualTo(TASK_ID);
             }
 
             @Test
             @DisplayName("매개변수로 전달한 값이 반영된 Task를 반환한다")
             void it_returns_task_reflecting_params() {
-                assertThat(givenExistingTask().getTitle()).isEqualTo(TASK_TITLE_UPDATED);
+                assertThat(withExistingTask().getTitle()).isEqualTo(TASK_TITLE_UPDATED);
             }
         }
 
@@ -126,7 +125,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(this::givenNotExistingTask)
+                assertThatThrownBy(this::withoutExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 
@@ -137,11 +136,11 @@ class TaskServiceTest {
     @DisplayName("deleteTask 메소드는")
     class Describe_deleteTask {
         abstract class ContextDeleting {
-            Task givenExistingTask() {
+            Task withExistingTask() {
                 return service.deleteTask(TASK_ID);
             }
 
-            void givenNotExistingTask() {
+            void withoutNotExistingTask() {
                 service.deleteTask(TASK_ID_NOT_EXISTING);
             }
         }
@@ -152,7 +151,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
+                assertThat(withExistingTask().getId()).isEqualTo(TASK_ID);
             }
         }
 
@@ -163,7 +162,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(this::givenNotExistingTask)
+                assertThatThrownBy(this::withoutNotExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -35,11 +35,11 @@ class TaskServiceTest {
     @DisplayName("getTasks 메소드는")
     class Describe_getTasks {
         @Test
-        @DisplayName("Collection 타입으로 값을 반환한다")
+        @DisplayName("List 타입의 Collection으로 값을 반환한다")
         void it_returns_list() {
             final List<Task> actual = service.getTasks();
 
-            assertThat(actual).isInstanceOf(Collection.class);
+            assertThat(actual).isInstanceOf(List.class);
         }
     }
 
@@ -140,8 +140,6 @@ class TaskServiceTest {
     @DisplayName("deleteTask 메소드는")
     class Describe_deleteTask {
         abstract class ContextDeleting {
-            final Task task = new Task(TASK_TITLE_UPDATED);
-
             Task givenExistingTask() {
                 return service.deleteTask(TASK_ID);
             }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -1,0 +1,80 @@
+package com.codesoom.assignment.application;
+
+
+import com.codesoom.assignment.TaskNotFoundException;
+import com.codesoom.assignment.models.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("TaskService 클래스")
+class TaskServiceTest {
+    private TaskService service;
+    private final String TASK_TITLE = "Test Task";
+    private final Long TASK_ID = 1L;
+    private final Long TASK_ID_NOT_EXISTING = 0L;
+    private final int TASKS_SIZE = 1;
+
+    @BeforeEach
+    void setUp() {
+        Task task = new Task();
+        task.setTitle(TASK_TITLE);
+
+        service = new TaskService();
+        service.createTask(task);
+    }
+
+    @Nested
+    @DisplayName("getTasks 메소드는")
+    class Describe_getTasks {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task 1개만 존재한다면")
+        class Context_with_default_task {
+            @Test
+            @DisplayName("반환값의 사이즈는 1이다")
+            void it_returns_1_size_of_Collection() {
+                final int actual = service.getTasks().size();
+                assertThat(actual).isEqualTo(TASKS_SIZE);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("getTask 메소드는")
+    class Describe_getTask {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 조회한다면")
+        class Context_with_default_task {
+            @Test
+            @DisplayName("기본 생성된 Task의 id값을 반환한다")
+            void it_returns_default_task_id() {
+                final Long actual = service.getTask(TASK_ID).getId();
+                assertThat(actual).isEqualTo(TASK_ID);
+            }
+
+            @Test
+            @DisplayName("기본 생성된 Task의 title값을 반환한다")
+            void it_returns_default_task_title() {
+                final String actual = service.getTask(TASK_ID).getTitle();
+                assertThat(actual).isEqualTo(TASK_TITLE);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 조회한다면")
+        class Context_with_not_existing_task {
+            @Test
+            @DisplayName("TaskNotFoundException이 발생한다")
+            void it_throws_exception() {
+                assertThatThrownBy(() -> service.getTask(TASK_ID_NOT_EXISTING))
+                        .isInstanceOf(TaskNotFoundException.class);
+            }
+
+        }
+    }
+
+}

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("TaskService 클래스의")
+@DisplayName("TaskService 클래스 ")
 class TaskServiceTest {
     private TaskService service;
     private final String TASK_TITLE = "Test Task";
@@ -60,7 +60,7 @@ class TaskServiceTest {
                 return service.getTask(TASK_ID);
             }
 
-            void withoutNotExistingTask() {
+            void withoutExistingTask() {
                 service.getTask(TASK_ID_NOT_EXISTING);
             }
         }
@@ -79,9 +79,9 @@ class TaskServiceTest {
         @DisplayName("만약 존재하지 않는 Task를 조회한다면")
         class Context_with_not_existing_task extends ContextGetting {
             @Test
-            @DisplayName("TaskNotFoundException을 발생시킨다")
+            @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(this::withoutNotExistingTask)
+                assertThatThrownBy(this::withoutExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 
@@ -140,7 +140,7 @@ class TaskServiceTest {
                 return service.deleteTask(TASK_ID);
             }
 
-            void withoutNotExistingTask() {
+            void withoutExistingTask() {
                 service.deleteTask(TASK_ID_NOT_EXISTING);
             }
         }
@@ -162,7 +162,7 @@ class TaskServiceTest {
             @Test
             @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(this::withoutNotExistingTask)
+                assertThatThrownBy(this::withoutExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class TaskServiceTest {
     private TaskService service;
     private final String TASK_TITLE = "Test Task";
+    private final String TASK_TITLE_UPDATED = "Updated Task";
     private final Long TASK_ID = 1L;
     private final Long TASK_ID_NOT_EXISTING = 0L;
     private final int TASKS_SIZE = 1;
@@ -76,5 +77,49 @@ class TaskServiceTest {
 
         }
     }
+
+    @Nested
+    @DisplayName("updateTask 메소드는")
+    class Describe_updateTask {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 수정한다면")
+        class Context_with_default_task {
+            @Test
+            @DisplayName("Task를 반환하는데, 반환한 Task의 id와 기본 생성된 Task의 id는 동일하다")
+            void it_returns_task_having_id_equal_to_default_task_id() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                final Long actual = service.updateTask(TASK_ID, task).getId();
+                assertThat(actual).isEqualTo(TASK_ID);
+            }
+
+            @Test
+            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 요청 시 전달한 Task의 title과 동일한다")
+            void it_returns_task_having_title_equal_to_task_title_delivered() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                final String actual = service.updateTask(TASK_ID, task).getTitle();
+                assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 조회한다면")
+        class Context_with_not_existing_task {
+            @Test
+            @DisplayName("TaskNotFoundException을 발생시킨다")
+            void it_throws_exception() {
+                final Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                assertThatThrownBy(() -> service.updateTask(TASK_ID_NOT_EXISTING, task))
+                        .isInstanceOf(TaskNotFoundException.class);
+            }
+
+        }
+    }
+    
 
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -59,25 +59,33 @@ class TaskServiceTest {
     @Nested
     @DisplayName("getTask 메소드는")
     class Describe_getTask {
+        abstract class ContextGetting {
+            Task givenExistingTask() {
+                return service.getTask(TASK_ID);
+            }
+
+            void givenNotExistingTask() {
+                service.getTask(TASK_ID_NOT_EXISTING);
+            }
+        }
+
         @Nested
         @DisplayName("만약 존재하는 Task를 상세조회한다면")
-        class Context_with_existing_task {
+        class Context_with_existing_task extends ContextGetting {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                final Task actual = service.getTask(TASK_ID);
-
-                assertThat(actual.getId()).isEqualTo(TASK_ID);
+                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
             }
         }
 
         @Nested
         @DisplayName("만약 존재하지 않는 Task를 조회한다면")
-        class Context_with_not_existing_task {
+        class Context_with_not_existing_task extends ContextGetting {
             @Test
             @DisplayName("TaskNotFoundException을 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(() -> service.getTask(TASK_ID_NOT_EXISTING))
+                assertThatThrownBy(this::givenNotExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 
@@ -89,13 +97,16 @@ class TaskServiceTest {
     class Describe_updateTask {
         abstract class ContextUpdating {
             final Task task = new Task(TASK_TITLE_UPDATED);
-            Task givenExistingTask(){
+
+            Task givenExistingTask() {
                 return service.updateTask(TASK_ID, task);
             }
-            void givenNotExistingTask(){
+
+            void givenNotExistingTask() {
                 service.updateTask(TASK_ID_NOT_EXISTING, task);
             }
         }
+
         @Nested
         @DisplayName("만약 존재하는 Task를 수정한다면")
         class Context_with_existing_task extends ContextUpdating {
@@ -128,25 +139,36 @@ class TaskServiceTest {
     @Nested
     @DisplayName("deleteTask 메소드는")
     class Describe_deleteTask {
+        abstract class ContextDeleting {
+            final Task task = new Task(TASK_TITLE_UPDATED);
+
+            Task givenExistingTask() {
+                return service.deleteTask(TASK_ID);
+            }
+
+            void givenNotExistingTask() {
+                service.deleteTask(TASK_ID_NOT_EXISTING);
+            }
+        }
+
         @Nested
         @DisplayName("만약 존재하는 Task를 삭제한다면")
-        class Context_with_existing_task {
+        class Context_with_existing_task extends ContextDeleting {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
-                final Task actual = service.deleteTask(TASK_ID);
-
-                assertThat(actual.getId()).isEqualTo(TASK_ID);
+                assertThat(givenExistingTask().getId()).isEqualTo(TASK_ID);
             }
         }
 
         @Nested
         @DisplayName("만약 존재하지 않는 Task를 삭제한다면")
-        class Context_with_not_existing_task {
+        class Context_with_not_existing_task extends ContextDeleting {
+
             @Test
             @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
-                assertThatThrownBy(() -> service.deleteTask(TASK_ID_NOT_EXISTING))
+                assertThatThrownBy(this::givenNotExistingTask)
                         .isInstanceOf(TaskNotFoundException.class);
             }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -128,22 +128,22 @@ class TaskServiceTest {
     @DisplayName("deleteTask 메소드는")
     class Describe_deleteTask {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 삭제한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 삭제한다면")
+        class Context_with_existing_task {
             @Test
-            @DisplayName("삭제된 기본생성 Task를 조회할 때 Not Found Exception이 발생한다")
+            @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_throws_exception() {
-                service.deleteTask(TASK_ID);
-                assertThatThrownBy(() -> service.getTask(TASK_ID))
-                        .isInstanceOf(TaskNotFoundException.class);
+                final Task actual = service.deleteTask(TASK_ID);
+
+                assertThat(actual.getId()).isEqualTo(TASK_ID);
             }
         }
 
         @Nested
-        @DisplayName("만약 존재하지 않는 Task를 조회한다면")
+        @DisplayName("만약 존재하지 않는 Task를 삭제한다면")
         class Context_with_not_existing_task {
             @Test
-            @DisplayName("TaskNotFoundException을 발생시킨다")
+            @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
                 assertThatThrownBy(() -> service.deleteTask(TASK_ID_NOT_EXISTING))
                         .isInstanceOf(TaskNotFoundException.class);

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -14,14 +14,13 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@DisplayName("TaskService 클래스")
+@DisplayName("TaskService 클래스의")
 class TaskServiceTest {
     private TaskService service;
     private final String TASK_TITLE = "Test Task";
     private final String TASK_TITLE_UPDATED = "Updated Task";
     private final Long TASK_ID = 1L;
     private final Long TASK_ID_NOT_EXISTING = 0L;
-    private final int TASKS_SIZE = 1;
 
     @BeforeEach
     void setUp() {

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -47,16 +47,7 @@ class TaskServiceTest {
     @DisplayName("createTasks 메소드는")
     class Describe_createTasks {
         @Test
-        @DisplayName("Task 타입의 형태로 값을 반환한다")
-        void it_returns_id_not_null() {
-            final Task task = new Task();
-
-            final Task actual = service.createTask(task);
-            assertThat(actual).isInstanceOf(Task.class);
-        }
-
-        @Test
-        @DisplayName("매개변수로 전달한 값이 모두 반영되어 생성된 Task를 반환한다")
+        @DisplayName("매개변수로 전달한 값이 반영된 Task를 반환한다")
         void it_returns_task_reflecting_params() {
             final Task task = new Task(TASK_TITLE_UPDATED);
 
@@ -72,17 +63,10 @@ class TaskServiceTest {
         @DisplayName("만약 존재하는 Task를 상세조회한다면")
         class Context_with_existing_task {
             @Test
-            @DisplayName("매개변수로 전달한 id와 동일한 id를 가지고 있는 Task를 반환한다")
+            @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
             void it_returns_task_having_id_equal_to_param() {
                 final Task actual = service.getTask(TASK_ID);
                 assertThat(actual.getId()).isEqualTo(TASK_ID);
-            }
-
-            @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 기본 생성된 Task의 title은 동일하다")
-            void it_returns_task_having_title_equal_to_default_task_title() {
-                final String actual = service.getTask(TASK_ID).getTitle();
-                assertThat(actual).isEqualTo(TASK_TITLE);
             }
         }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -106,7 +106,7 @@ class TaskServiceTest {
         }
 
         @Nested
-        @DisplayName("만약 존재하지 않는 Task를 조회한다면")
+        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
         class Context_with_not_existing_task {
             @Test
             @DisplayName("TaskNotFoundException을 발생시킨다")
@@ -120,6 +120,33 @@ class TaskServiceTest {
 
         }
     }
-    
+
+    @Nested
+    @DisplayName("deleteTask 메소드는")
+    class Describe_deleteTask {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 삭제한다면")
+        class Context_with_default_task {
+            @Test
+            @DisplayName("삭제된 기본생성 Task를 조회할 때 Not Found Exception이 발생한다")
+            void it_throws_exception() {
+                service.deleteTask(TASK_ID);
+                assertThatThrownBy(() -> service.getTask(TASK_ID))
+                        .isInstanceOf(TaskNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 조회한다면")
+        class Context_with_not_existing_task {
+            @Test
+            @DisplayName("TaskNotFoundException을 발생시킨다")
+            void it_throws_exception() {
+                assertThatThrownBy(() -> service.deleteTask(TASK_ID_NOT_EXISTING))
+                        .isInstanceOf(TaskNotFoundException.class);
+            }
+
+        }
+    }
 
 }

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -32,10 +32,10 @@ class TaskServiceTest {
     @DisplayName("getTasks 메소드는")
     class Describe_getTasks {
         @Nested
-        @DisplayName("만약 기본 생성된 Task 1개만 존재한다면")
+        @DisplayName("만약 기본 생성된 Task가 1개만 존재한다면")
         class Context_with_default_task {
             @Test
-            @DisplayName("반환값의 사이즈는 1이다")
+            @DisplayName("사이즈가 1인 콜렉션을 반환한다")
             void it_returns_1_size_of_Collection() {
                 final int actual = service.getTasks().size();
                 assertThat(actual).isEqualTo(TASKS_SIZE);
@@ -50,15 +50,15 @@ class TaskServiceTest {
         @DisplayName("만약 기본 생성된 Task를 조회한다면")
         class Context_with_default_task {
             @Test
-            @DisplayName("기본 생성된 Task의 id값을 반환한다")
-            void it_returns_default_task_id() {
+            @DisplayName("Task를 반환하는데, 반환한 Task의 id와 기본 생성된 Task의 id는 동일하다")
+            void it_returns_task_having_id_equal_to_default_task_id() {
                 final Long actual = service.getTask(TASK_ID).getId();
                 assertThat(actual).isEqualTo(TASK_ID);
             }
 
             @Test
-            @DisplayName("기본 생성된 Task의 title값을 반환한다")
-            void it_returns_default_task_title() {
+            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 기본 생성된 Task의 title은 동일하다")
+            void it_returns_task_having_title_equal_to_default_task_title() {
                 final String actual = service.getTask(TASK_ID).getTitle();
                 assertThat(actual).isEqualTo(TASK_TITLE);
             }
@@ -68,7 +68,7 @@ class TaskServiceTest {
         @DisplayName("만약 존재하지 않는 Task를 조회한다면")
         class Context_with_not_existing_task {
             @Test
-            @DisplayName("TaskNotFoundException이 발생한다")
+            @DisplayName("TaskNotFoundException을 발생시킨다")
             void it_throws_exception() {
                 assertThatThrownBy(() -> service.getTask(TASK_ID_NOT_EXISTING))
                         .isInstanceOf(TaskNotFoundException.class);

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -39,6 +39,7 @@ class TaskServiceTest {
         @DisplayName("Collection 타입의 형태로 값을 반환한다")
         void it_returns_list() {
             final List<Task> actual = service.getTasks();
+
             assertThat(actual).isInstanceOf(Collection.class);
         }
     }
@@ -88,11 +89,11 @@ class TaskServiceTest {
     @DisplayName("updateTask 메소드는")
     class Describe_updateTask {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 수정한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 수정한다면")
+        class Context_with_existing_task {
             @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 id와 기본 생성된 Task의 id는 동일하다")
-            void it_returns_task_having_id_equal_to_default_task_id() {
+            @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
+            void it_returns_task_having_id_equal_to_param() {
                 final Task task = new Task(TASK_TITLE_UPDATED);
 
                 final Task actual = service.updateTask(TASK_ID, task);
@@ -100,8 +101,8 @@ class TaskServiceTest {
             }
 
             @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 요청 시 전달한 Task의 title과 동일한다")
-            void it_returns_task_having_title_equal_to_task_title_delivered() {
+            @DisplayName("매개변수로 전달한 값이 반영된 Task를 반환한다")
+            void it_returns_task_reflecting_params() {
                 final Task task = new Task(TASK_TITLE_UPDATED);
 
                 final Task actual = service.updateTask(TASK_ID, task);
@@ -113,7 +114,7 @@ class TaskServiceTest {
         @DisplayName("만약 존재하지 않는 Task를 수정한다면")
         class Context_with_not_existing_task {
             @Test
-            @DisplayName("TaskNotFoundException을 발생시킨다")
+            @DisplayName("예외를 발생시킨다")
             void it_throws_exception() {
                 final Task task = new Task(TASK_TITLE_UPDATED);
 
@@ -132,7 +133,7 @@ class TaskServiceTest {
         class Context_with_existing_task {
             @Test
             @DisplayName("매개변수로 전달한 값을 Id로 가지고 있는 Task를 반환한다")
-            void it_throws_exception() {
+            void it_returns_task_having_id_equal_to_param() {
                 final Task actual = service.deleteTask(TASK_ID);
 
                 assertThat(actual.getId()).isEqualTo(TASK_ID);

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -21,7 +21,7 @@ class TaskServiceTest {
 
     @BeforeEach
     void setUp() {
-        Task task = new Task();
+        final Task task = new Task();
         task.setTitle(TASK_TITLE);
 
         service = new TaskService();

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,55 +34,34 @@ class TaskServiceTest {
     @Nested
     @DisplayName("getTasks 메소드는")
     class Describe_getTasks {
-        @Nested
-        @DisplayName("만약 기본 생성된 Task가 1개만 존재한다면")
-        class Context_with_default_task {
-            @Test
-            @DisplayName("사이즈가 1인 콜렉션을 반환한다")
-            void it_returns_1_size_of_Collection() {
-                final int actual = service.getTasks().size();
-                assertThat(actual).isEqualTo(TASKS_SIZE);
-            }
+        @Test
+        @DisplayName("List 타입를 반환한다")
+        void it_returns_list() {
+            final List<Task> actual = service.getTasks();
+            assertThat(actual).isInstanceOf(List.class);
         }
     }
 
     @Nested
     @DisplayName("createTasks 메소드는")
     class Describe_createTasks {
-        @Nested
-        @DisplayName("만약 기본 생성된 Task가 1개만 존재한다면")
-        class Context_with_default_task {
-            @Test
-            @DisplayName("Task를 생성하여 Task의 개수가 총 2개가 된다")
-            void it_makes_2_size_of_Collection() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
+        @Test
+        @DisplayName("Task 타입을 반환한다")
+        void it_returns_id_not_null() {
+            final Task task = new Task();
 
-                service.createTask(task);
-                final int actual = service.getTasks().size();
-                assertThat(actual).isEqualTo(TASKS_SIZE + 1);
-            }
+            final Task actual = service.createTask(task);
+            assertThat(actual).isInstanceOf(Task.class);
+        }
 
-            @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 id는 Null이 아니다")
-            void it_returns_id_not_null() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
+        @Test
+        @DisplayName("반환한 Task의 title과 매개변수로 전달한 Task의 title은 동일하다")
+        void it_returns_task_having_title_equal_to_default_task_title() {
+            final Task task = new Task();
+            task.setTitle(TASK_TITLE_UPDATED);
 
-                final Long actual = service.createTask(task).getId();
-                assertThat(actual).isNotNull();
-            }
-
-            @Test
-            @DisplayName("Task를 반환하는데, 반환한 Task의 title과 새로 생성한 Task의 title은 동일하다")
-            void it_returns_task_having_title_equal_to_default_task_title() {
-                final Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
-
-                final String actual = service.createTask(task).getTitle();
-                assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
-            }
-
+            final String actual = service.createTask(task).getTitle();
+            assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
         }
     }
 

--- a/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
+++ b/app/src/test/java/com/codesoom/assignment/application/TaskServiceTest.java
@@ -35,10 +35,10 @@ class TaskServiceTest {
     @DisplayName("getTasks 메소드는")
     class Describe_getTasks {
         @Test
-        @DisplayName("List 타입를 반환한다")
+        @DisplayName("Collection 타입의 형태로 값을 반환한다")
         void it_returns_list() {
             final List<Task> actual = service.getTasks();
-            assertThat(actual).isInstanceOf(List.class);
+            assertThat(actual).isInstanceOf(Collection.class);
         }
     }
 
@@ -46,7 +46,7 @@ class TaskServiceTest {
     @DisplayName("createTasks 메소드는")
     class Describe_createTasks {
         @Test
-        @DisplayName("Task 타입을 반환한다")
+        @DisplayName("Task 타입의 형태로 값을 반환한다")
         void it_returns_id_not_null() {
             final Task task = new Task();
 

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerMockingTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerMockingTest.java
@@ -1,7 +1,0 @@
-package com.codesoom.assignment.controllers;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class TaskControllerMockingTest {
-
-}

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerMockingTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerMockingTest.java
@@ -1,0 +1,7 @@
+package com.codesoom.assignment.controllers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TaskControllerMockingTest {
+
+}

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -28,7 +28,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환값 내 Task의 개수는 1개여야 한다")
+    @DisplayName("기본 생성된 Task가 존재하면, 목록조회 요청 시 반환값 내 Task도 존재한다")
     void whenList_returnEqualSize() {
         // WHEN
         final List<Task> actual = controller.list();
@@ -39,7 +39,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야 한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같다")
     void whenList_returnEqualId() {
         // WHEN
         final List<Task> actual = controller.list();
@@ -49,7 +49,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야 한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같다")
     void whenList_returnEqualTitle() {
         // WHEN
         final List<Task> actual = controller.list();
@@ -59,7 +59,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야 한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같다")
     void whenDetail_returnEqualId() {
         // WHEN
         final Task actual = controller.detail(TASK_ID);
@@ -69,7 +69,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야 한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같다")
     void whenDetail_returnEqualTitle() {
         // WHEN
         final Task actual = controller.detail(TASK_ID);
@@ -78,7 +78,7 @@ class TaskControllerTest {
         assertThat(actual.getTitle()).isEqualTo(TASK_TITLE);
     }
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 생성 요청 시 Task 목록 요청에 따른 반환값의 사이즈는 1이 증가해야 한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 생성 요청 시 Task 목록 요청에 따른 반환값의 사이즈는 1이 증가한다")
     void whenCreate_shouldSizeUp() {
         // WHEN
         controller.create(new Task(INPUT_TITLE));
@@ -90,7 +90,7 @@ class TaskControllerTest {
 
 
     @Test
-    @DisplayName("Task 생성 요청 시 반환된 Task의 title은 요청 시 전달한 title과 같아야 한다")
+    @DisplayName("Task 생성 요청 시 반환된 Task의 title은 요청 시 전달한 title과 같다")
     void whenCreate_returnTaskWithFields() {
         // WHEN
         final Task actual = controller.create(new Task(INPUT_TITLE));

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -1,0 +1,29 @@
+package com.codesoom.assignment.controllers;
+
+import com.codesoom.assignment.application.TaskService;
+import com.codesoom.assignment.models.Task;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskControllerTest {
+    private TaskService service;
+    private TaskController controller;
+    private final String TASK_TITLE = "Test Task";
+    private final Long TASK_ID = 1L;
+    private final int FIRST = 0;
+
+    @BeforeEach
+    void setUp() {
+        Task task = new Task();
+        task.setTitle(TASK_TITLE);
+
+        service = new TaskService();
+        service.createTask(task);
+        controller = new TaskController(service);
+    }
+
+}

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -1,7 +1,6 @@
 package com.codesoom.assignment.controllers;
 
 import com.codesoom.assignment.application.TaskService;
-import com.codesoom.assignment.dto.ErrorResponse;
 import com.codesoom.assignment.models.Task;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +15,6 @@ class TaskControllerTest {
     private TaskController controller;
     private final String TASK_TITLE = "Test Task";
     private final Long TASK_ID = 1L;
-    private final Long TASK_ID_NOT_EXISTING = 0L;
     private final int FIRST = 0;
 
     @BeforeEach
@@ -55,7 +53,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 하나만 존재하고, Task Id로 정상적으로 상세조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야한다")
     void whenDetail_returnEqualId() {
         Long actual = controller.detail(TASK_ID).getId();
 
@@ -63,7 +61,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 하나만 존재하고, Task Id로 정상적으로 상세조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야한다")
     void whenDetail_returnEqualTitle() {
         String actual = controller.detail(TASK_ID).getTitle();
 

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -1,6 +1,7 @@
 package com.codesoom.assignment.controllers;
 
 import com.codesoom.assignment.application.TaskService;
+import com.codesoom.assignment.dto.ErrorResponse;
 import com.codesoom.assignment.models.Task;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,7 @@ class TaskControllerTest {
     private TaskController controller;
     private final String TASK_TITLE = "Test Task";
     private final Long TASK_ID = 1L;
+    private final Long TASK_ID_NOT_EXISTING = 0L;
     private final int FIRST = 0;
 
     @BeforeEach
@@ -48,4 +50,17 @@ class TaskControllerTest {
         assertThat(actual).isEqualTo(TASK_TITLE);
     }
 
+    @Test
+    void Given_Task가_하나만_존재_When_상세_조회_요청_Then_반환된_Task_id_는_Service_내_Task_id와_같아야한다() {
+        Long actual = controller.detail(TASK_ID).getId();
+
+        assertThat(actual).isEqualTo(TASK_ID);
+    }
+
+    @Test
+    void Given_Task가_하나만_존재_When_상세_조회_요청_Then_반환된_Task_title_는_Service_내_Task_title와_같아야한다() {
+        String actual = controller.detail(TASK_ID).getTitle();
+
+        assertThat(actual).isEqualTo(TASK_TITLE);
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TaskControllerTest {
     private TaskService service;
@@ -33,8 +32,8 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환값 내 Task의 개수는 1개여야 한다")
     void whenList_returnEqualSize() {
-        List<Task> expected = service.getTasks();
-        List<Task> actual = controller.list();
+        final List<Task> expected = service.getTasks();
+        final List<Task> actual = controller.list();
 
         assertThat(actual).hasSameSizeAs(expected);
     }
@@ -42,7 +41,7 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야 한다")
     void whenList_returnEqualId() {
-        Long actual = controller.list().get(FIRST).getId();
+        final Long actual = controller.list().get(FIRST).getId();
 
         assertThat(actual).isEqualTo(TASK_ID);
     }
@@ -50,7 +49,7 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야 한다")
     void whenList_returnEqualTitle() {
-        String actual = controller.list().get(FIRST).getTitle();
+        final String actual = controller.list().get(FIRST).getTitle();
 
         assertThat(actual).isEqualTo(TASK_TITLE);
     }
@@ -58,7 +57,7 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야 한다")
     void whenDetail_returnEqualId() {
-        Long actual = controller.detail(TASK_ID).getId();
+        final Long actual = controller.detail(TASK_ID).getId();
 
         assertThat(actual).isEqualTo(TASK_ID);
     }
@@ -66,7 +65,7 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야 한다")
     void whenDetail_returnEqualTitle() {
-        String actual = controller.detail(TASK_ID).getTitle();
+        final String actual = controller.detail(TASK_ID).getTitle();
 
         assertThat(actual).isEqualTo(TASK_TITLE);
     }
@@ -101,12 +100,7 @@ class TaskControllerTest {
         final Task task = new Task();
         task.setTitle(INPUT_TITLE);
 
-        // 첫번째 방식
         final Long actual = controller.create(task).getId();
         assertThat(actual).isNotNull();
-
-        // 두번째 방식
-        assertThatThrownBy(()-> controller.create(task).getId())
-                .isNotInstanceOf(NullPointerException.class);
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -21,86 +21,91 @@ class TaskControllerTest {
 
     @BeforeEach
     void setUp() {
-        Task task = new Task();
-        task.setTitle(TASK_TITLE);
-
+        // GIVEN
         service = new TaskService();
-        service.createTask(task);
+        service.createTask(new Task(TASK_TITLE));
         controller = new TaskController(service);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환값 내 Task의 개수는 1개여야 한다")
     void whenList_returnEqualSize() {
-        final List<Task> expected = service.getTasks();
+        // WHEN
         final List<Task> actual = controller.list();
 
+        // THEN
+        final List<Task> expected = service.getTasks();
         assertThat(actual).hasSameSizeAs(expected);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야 한다")
     void whenList_returnEqualId() {
+        // WHEN
         final List<Task> actual = controller.list();
 
+        // THEN
         assertThat(actual.get(FIRST).getId()).isEqualTo(TASK_ID);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야 한다")
     void whenList_returnEqualTitle() {
+        // WHEN
         final List<Task> actual = controller.list();
 
+        // THEN
         assertThat(actual.get(FIRST).getTitle()).isEqualTo(TASK_TITLE);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야 한다")
     void whenDetail_returnEqualId() {
+        // WHEN
         final Task actual = controller.detail(TASK_ID);
 
+        // THEN
         assertThat(actual.getId()).isEqualTo(TASK_ID);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야 한다")
     void whenDetail_returnEqualTitle() {
+        // WHEN
         final Task actual = controller.detail(TASK_ID);
 
+        // THEN
         assertThat(actual.getTitle()).isEqualTo(TASK_TITLE);
     }
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 생성 요청 시 Task 목록 요청에 따른 반환값의 사이즈는 1이 증가해야 한다")
     void whenCreate_shouldSizeUp() {
-        final int expected = TASKS_SIZE + 1;
-        final Task task = new Task();
-        task.setTitle(INPUT_TITLE);
+        // WHEN
+        controller.create(new Task(INPUT_TITLE));
 
-        controller.create(task);
+        // THEN
         final List<Task> actual = controller.list();
-
-        assertThat(actual.size()).isEqualTo(expected);
+        assertThat(actual.size()).isEqualTo(TASKS_SIZE + 1);
     }
 
 
     @Test
     @DisplayName("Task 생성 요청 시 반환된 Task의 title은 요청 시 전달한 title과 같아야 한다")
     void whenCreate_returnTaskWithFields() {
-        final Task task = new Task();
-        task.setTitle(INPUT_TITLE);
+        // WHEN
+        final Task actual = controller.create(new Task(INPUT_TITLE));
 
-        final Task actual = controller.create(task);
-
+        // THEN
         assertThat(actual.getTitle()).isEqualTo(INPUT_TITLE);
     }
 
     @Test
     @DisplayName("Task 생성 요청 시 반환된 Task의 id는 null일 수 없다")
     void whenCreate_returnTaskWithNotNullId() {
-        final Task task = new Task();
-        task.setTitle(INPUT_TITLE);
+        // WHEN
+        final Task actual = controller.create(new Task(INPUT_TITLE));
 
-        final Task actual = controller.create(task);
+        // THEN
         assertThat(actual.getId()).isNotNull();
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -26,4 +26,26 @@ class TaskControllerTest {
         controller = new TaskController(service);
     }
 
+    @Test
+    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환값_내_Task_개수는_Service_반환값_개수와_같다() {
+        List<Task> expected = service.getTasks();
+        List<Task> actual = controller.list();
+
+        assertThat(actual).hasSameSizeAs(expected);
+    }
+
+    @Test
+    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환된_Task_id_는_Service_내_Task_id와_같아야한다() {
+        Long actual = controller.list().get(FIRST).getId();
+
+        assertThat(actual).isEqualTo(TASK_ID);
+    }
+
+    @Test
+    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환된_Task_title_는_Service_내_Task_title와_같아야한다() {
+        String actual = controller.list().get(FIRST).getTitle();
+
+        assertThat(actual).isEqualTo(TASK_TITLE);
+    }
+
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -9,13 +9,16 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TaskControllerTest {
     private TaskService service;
     private TaskController controller;
     private final String TASK_TITLE = "Test Task";
+    private final String INPUT_TITLE = "Input Task Title";
     private final Long TASK_ID = 1L;
     private final int FIRST = 0;
+    private final int TASKS_SIZE = 1;
 
     @BeforeEach
     void setUp() {
@@ -37,7 +40,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야 한다")
     void whenList_returnEqualId() {
         Long actual = controller.list().get(FIRST).getId();
 
@@ -45,7 +48,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야 한다")
     void whenList_returnEqualTitle() {
         String actual = controller.list().get(FIRST).getTitle();
 
@@ -53,7 +56,7 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야 한다")
     void whenDetail_returnEqualId() {
         Long actual = controller.detail(TASK_ID).getId();
 
@@ -61,10 +64,49 @@ class TaskControllerTest {
     }
 
     @Test
-    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야한다")
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야 한다")
     void whenDetail_returnEqualTitle() {
         String actual = controller.detail(TASK_ID).getTitle();
 
         assertThat(actual).isEqualTo(TASK_TITLE);
+    }
+    @Test
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 생성 요청 시 Task 목록 요청에 따른 반환값의 사이즈는 1이 증가해야 한다")
+    void whenCreate_shouldSizeUp() {
+        final int expected = TASKS_SIZE + 1;
+        final Task task = new Task();
+        task.setTitle(INPUT_TITLE);
+
+        controller.create(task);
+        final int actual = controller.list().size();
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+
+    @Test
+    @DisplayName("Task 생성 요청 시 반환된 Task의 title은 요청 시 전달한 title과 같아야 한다")
+    void whenCreate_returnTaskWithFields() {
+        final Task task = new Task();
+        task.setTitle(INPUT_TITLE);
+
+        final String actual = controller.create(task).getTitle();
+
+        assertThat(actual).isEqualTo(INPUT_TITLE);
+    }
+
+    @Test
+    @DisplayName("Task 생성 요청 시 반환된 Task의 id는 null일 수 없다")
+    void whenCreate_returnTaskWithNotNullId() {
+        final Task task = new Task();
+        task.setTitle(INPUT_TITLE);
+
+        // 첫번째 방식
+        final Long actual = controller.create(task).getId();
+        assertThat(actual).isNotNull();
+
+        // 두번째 방식
+        assertThatThrownBy(()-> controller.create(task).getId())
+                .isNotInstanceOf(NullPointerException.class);
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -41,33 +41,33 @@ class TaskControllerTest {
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야 한다")
     void whenList_returnEqualId() {
-        final Long actual = controller.list().get(FIRST).getId();
+        final List<Task> actual = controller.list();
 
-        assertThat(actual).isEqualTo(TASK_ID);
+        assertThat(actual.get(FIRST).getId()).isEqualTo(TASK_ID);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야 한다")
     void whenList_returnEqualTitle() {
-        final String actual = controller.list().get(FIRST).getTitle();
+        final List<Task> actual = controller.list();
 
-        assertThat(actual).isEqualTo(TASK_TITLE);
+        assertThat(actual.get(FIRST).getTitle()).isEqualTo(TASK_TITLE);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 id는 기본 생성된 Task의 id와 같아야 한다")
     void whenDetail_returnEqualId() {
-        final Long actual = controller.detail(TASK_ID).getId();
+        final Task actual = controller.detail(TASK_ID);
 
-        assertThat(actual).isEqualTo(TASK_ID);
+        assertThat(actual.getId()).isEqualTo(TASK_ID);
     }
 
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 상세조회 요청 시 반환된 Task의 title은 기본 생성된 Task의 title과 같아야 한다")
     void whenDetail_returnEqualTitle() {
-        final String actual = controller.detail(TASK_ID).getTitle();
+        final Task actual = controller.detail(TASK_ID);
 
-        assertThat(actual).isEqualTo(TASK_TITLE);
+        assertThat(actual.getTitle()).isEqualTo(TASK_TITLE);
     }
     @Test
     @DisplayName("기본 생성된 Task가 하나만 존재하면, 해당 Task 생성 요청 시 Task 목록 요청에 따른 반환값의 사이즈는 1이 증가해야 한다")
@@ -77,9 +77,9 @@ class TaskControllerTest {
         task.setTitle(INPUT_TITLE);
 
         controller.create(task);
-        final int actual = controller.list().size();
+        final List<Task> actual = controller.list();
 
-        assertThat(actual).isEqualTo(expected);
+        assertThat(actual.size()).isEqualTo(expected);
     }
 
 
@@ -89,9 +89,9 @@ class TaskControllerTest {
         final Task task = new Task();
         task.setTitle(INPUT_TITLE);
 
-        final String actual = controller.create(task).getTitle();
+        final Task actual = controller.create(task);
 
-        assertThat(actual).isEqualTo(INPUT_TITLE);
+        assertThat(actual.getTitle()).isEqualTo(INPUT_TITLE);
     }
 
     @Test
@@ -100,7 +100,7 @@ class TaskControllerTest {
         final Task task = new Task();
         task.setTitle(INPUT_TITLE);
 
-        final Long actual = controller.create(task).getId();
-        assertThat(actual).isNotNull();
+        final Task actual = controller.create(task);
+        assertThat(actual.getId()).isNotNull();
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerTest.java
@@ -4,6 +4,7 @@ import com.codesoom.assignment.application.TaskService;
 import com.codesoom.assignment.dto.ErrorResponse;
 import com.codesoom.assignment.models.Task;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -29,7 +30,8 @@ class TaskControllerTest {
     }
 
     @Test
-    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환값_내_Task_개수는_Service_반환값_개수와_같다() {
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환값 내 Task의 개수는 1개여야 한다")
+    void whenList_returnEqualSize() {
         List<Task> expected = service.getTasks();
         List<Task> actual = controller.list();
 
@@ -37,28 +39,32 @@ class TaskControllerTest {
     }
 
     @Test
-    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환된_Task_id_는_Service_내_Task_id와_같아야한다() {
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야한다")
+    void whenList_returnEqualId() {
         Long actual = controller.list().get(FIRST).getId();
 
         assertThat(actual).isEqualTo(TASK_ID);
     }
 
     @Test
-    void Given_Task가_하나만_존재_When_목록_조회_요청_Then_반환된_Task_title_는_Service_내_Task_title와_같아야한다() {
+    @DisplayName("기본 생성된 Task가 하나만 존재하면, 목록조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야한다")
+    void whenList_returnEqualTitle() {
         String actual = controller.list().get(FIRST).getTitle();
 
         assertThat(actual).isEqualTo(TASK_TITLE);
     }
 
     @Test
-    void Given_Task가_하나만_존재_When_상세_조회_요청_Then_반환된_Task_id_는_Service_내_Task_id와_같아야한다() {
+    @DisplayName("기본 생성된 하나만 존재하고, Task Id로 정상적으로 상세조회 요청 시 반환된 Task id는 기본 생성된 Task의 id와 같아야한다")
+    void whenDetail_returnEqualId() {
         Long actual = controller.detail(TASK_ID).getId();
 
         assertThat(actual).isEqualTo(TASK_ID);
     }
 
     @Test
-    void Given_Task가_하나만_존재_When_상세_조회_요청_Then_반환된_Task_title_는_Service_내_Task_title와_같아야한다() {
+    @DisplayName("기본 생성된 하나만 존재하고, Task Id로 정상적으로 상세조회 요청 시 반환된 Task title은 기본 생성된 Task의 title과 같아야한다")
+    void whenDetail_returnEqualTitle() {
         String actual = controller.detail(TASK_ID).getTitle();
 
         assertThat(actual).isEqualTo(TASK_TITLE);

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -62,7 +62,7 @@ class TaskControllerWebTest {
         @Test
         @DisplayName("HTTP Status Code 200 OK 응답한다")
         void it_responds_with_200_ok() throws Exception {
-            mockMvc.perform(get(DEFAULT_PATH))
+            mockMvc.perform(get("/tasks"))
                     .andExpect(status().isOk());
         }
     }
@@ -82,7 +82,7 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                mockMvc.perform(get(DEFAULT_PATH + "/" + TASK_ID))
+                mockMvc.perform(get("/tasks/" + TASK_ID))
                         .andExpect(status().isOk());
             }
         }
@@ -99,7 +99,7 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
             void it_responds_with_404() throws Exception {
-                mockMvc.perform(get(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                mockMvc.perform(get("/tasks/" + TASK_ID_NOT_EXISTING))
                         .andExpect(status().isNotFound());
             }
 
@@ -129,7 +129,7 @@ class TaskControllerWebTest {
                 task.setTitle(TASK_TITLE_UPDATED);
                 String content = objectMapper.writeValueAsString(task);
 
-                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID)
+                mockMvc.perform(put("/tasks/" + TASK_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(content))
                         .andExpect(status().isOk());
@@ -188,7 +188,7 @@ class TaskControllerWebTest {
                 task.setTitle(TASK_TITLE_UPDATED);
                 String content = objectMapper.writeValueAsString(task);
 
-                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID)
+                mockMvc.perform(patch("/tasks/" + TASK_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(content))
                         .andExpect(status().isOk());
@@ -237,7 +237,7 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 204 NO CONTENT 응답한다")
             void it_responds_with_204() throws Exception {
-                mockMvc.perform(delete(DEFAULT_PATH + "/" + TASK_ID))
+                mockMvc.perform(delete("/tasks/" + TASK_ID))
                         .andExpect(status().isNoContent());
             }
         }
@@ -254,7 +254,7 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
             void it_responds_with_404() throws Exception {
-                mockMvc.perform(delete(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                mockMvc.perform(delete("/tasks/" + TASK_ID_NOT_EXISTING))
                         .andExpect(status().isNotFound());
             }
 

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -230,4 +230,19 @@ class TaskControllerWebTest {
     private String taskToJson(Task task) throws JsonProcessingException {
         return objectMapper.writeValueAsString(task);
     }
+
+    @Nested
+    @DisplayName("create 메소드는")
+    class Describe_create {
+            @Test
+            @DisplayName("HTTP Status Code 201 CREATED 응답한다")
+            void it_responds_with_201() throws Exception {
+                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
+
+                mockMvc.perform(post("/tasks")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(content))
+                        .andExpect(status().isCreated());
+            }
+        }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -222,10 +222,6 @@ class TaskControllerWebTest {
         }
     }
 
-    private String taskToJson(Task task) throws JsonProcessingException {
-        return objectMapper.writeValueAsString(task);
-    }
-
     @Nested
     @DisplayName("create 메소드는")
     class Describe_create {
@@ -237,5 +233,9 @@ class TaskControllerWebTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isCreated());
         }
+    }
+
+    private String taskToJson(Task task) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(task);
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -16,7 +16,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.util.LinkedList;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -130,33 +132,19 @@ class TaskControllerWebTest {
             }
         }
 
-        @Nested
-        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
-        class Context_without_existing_task {
-            @BeforeEach
-            void setUp() {
-                final Task task = tasks.get(FIRST);
-                final Task newTask = new Task();
-                newTask.setTitle(TASK_TITLE_UPDATED);
-                task.setTitle(TASK_TITLE_UPDATED);
-
-                given(service.updateTask(TASK_ID_NOT_EXISTING, newTask))
-                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
-            }
-
+//        @Nested
+//        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
+//        class Context_without_existing_task {
 //            @Test
 //            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
 //            void it_responds_with_404() throws Exception {
-//                Task task = new Task();
-//                task.setTitle(TASK_TITLE_UPDATED);
-//                String content = objectMapper.writeValueAsString(task);
-//
-//                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+//                mockMvc.perform(put("/tasks/" + TASK_ID_NOT_EXISTING)
 //                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(content))
+//                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+//                                .accept(MediaType.APPLICATION_JSON))
 //                        .andExpect(status().isNotFound());
 //            }
-        }
+//        }
     }
 
     @Nested
@@ -170,7 +158,7 @@ class TaskControllerWebTest {
                 final Task task = tasks.get(FIRST);
                 task.setTitle(TASK_TITLE_UPDATED);
 
-                given(service.updateTask(TASK_ID,  new Task(TASK_TITLE_UPDATED))).willReturn(task);
+                given(service.updateTask(TASK_ID, new Task(TASK_TITLE_UPDATED))).willReturn(task);
             }
 
             @Test
@@ -188,20 +176,13 @@ class TaskControllerWebTest {
 //        @Nested
 //        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
 //        class Context_without_existing_task {
-//            @BeforeEach
-//            void setUp() {
-//                given(service.updateTask(TASK_ID_NOT_EXISTING, new Task(TASK_TITLE_UPDATED)))
-//                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
-//            }
-//
 //            @Test
 //            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
 //            void it_responds_with_404() throws Exception {
-//                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
-//
-//                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+//                mockMvc.perform(patch("/tasks/" + TASK_ID_NOT_EXISTING)
 //                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(content))
+//                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+//                                .accept(MediaType.APPLICATION_JSON))
 //                        .andExpect(status().isNotFound());
 //            }
 //        }
@@ -244,5 +225,9 @@ class TaskControllerWebTest {
             }
 
         }
+    }
+
+    private String taskToJson(Task task) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(task);
     }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -40,9 +40,7 @@ class TaskControllerWebTest {
 
     @BeforeEach
     void setUp() {
-        Task task = new Task();
-        task.setId(TASK_ID);
-        task.setTitle(TASK_TITLE);
+        Task task = new Task(TASK_ID, TASK_TITLE);
         tasks.add(task);
     }
 
@@ -115,19 +113,15 @@ class TaskControllerWebTest {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
-                final Task newTask = new Task();
-                newTask.setTitle(TASK_TITLE_UPDATED);
                 task.setTitle(TASK_TITLE_UPDATED);
 
-                given(service.updateTask(TASK_ID, newTask)).willReturn(task);
+                given(service.updateTask(TASK_ID, new Task(TASK_TITLE_UPDATED))).willReturn(task);
             }
 
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
-                String content = objectMapper.writeValueAsString(task);
+                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
 
                 mockMvc.perform(put("/tasks/" + TASK_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -174,19 +168,15 @@ class TaskControllerWebTest {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
-                final Task newTask = new Task();
-                newTask.setTitle(TASK_TITLE_UPDATED);
                 task.setTitle(TASK_TITLE_UPDATED);
 
-                given(service.updateTask(TASK_ID, newTask)).willReturn(task);
+                given(service.updateTask(TASK_ID,  new Task(TASK_TITLE_UPDATED))).willReturn(task);
             }
 
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
-                String content = objectMapper.writeValueAsString(task);
+                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
 
                 mockMvc.perform(patch("/tasks/" + TASK_ID)
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -195,31 +185,26 @@ class TaskControllerWebTest {
             }
         }
 
-        @Nested
-        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
-        class Context_without_existing_task {
-            @BeforeEach
-            void setUp() {
-                final Task newTask = new Task();
-                newTask.setTitle(TASK_TITLE_UPDATED);
-
-                given(service.updateTask(TASK_ID_NOT_EXISTING, newTask))
-                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
-            }
-
+//        @Nested
+//        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
+//        class Context_without_existing_task {
+//            @BeforeEach
+//            void setUp() {
+//                given(service.updateTask(TASK_ID_NOT_EXISTING, new Task(TASK_TITLE_UPDATED)))
+//                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+//            }
+//
 //            @Test
 //            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
 //            void it_responds_with_404() throws Exception {
-//                Task task = new Task();
-//                task.setTitle(TASK_TITLE_UPDATED);
-//                String content = objectMapper.writeValueAsString(task);
+//                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
 //
 //                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
 //                                .contentType(MediaType.APPLICATION_JSON)
 //                                .content(content))
 //                        .andExpect(status().isNotFound());
 //            }
-        }
+//        }
     }
 
     @Nested

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -14,7 +14,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -92,7 +92,7 @@ class TaskControllerWebTest {
 
             @Test
             @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
-            void it_responds_with_200_ok() throws Exception {
+            void it_responds_with_404() throws Exception {
                 mockMvc.perform(get(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
                         .andExpect(status().isNotFound());
             }
@@ -100,4 +100,130 @@ class TaskControllerWebTest {
         }
     }
 
+    @Nested
+    @DisplayName("update 메소드는")
+    class Describe_update {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 수정한다면")
+        class Context_with_default_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                final Task newTask = new Task();
+                newTask.setTitle("(UPDATED)" + TASK_TITLE);
+                task.setTitle("(UPDATED)" + TASK_TITLE);
+
+                given(service.updateTask(TASK_ID, newTask)).willReturn(task);
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 200 OK 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID))
+                        .andExpect(status().isOk());
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                given(service.updateTask(TASK_ID, task))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                        .andExpect(status().isNotFound());
+            }
+
+        }
+    }
+
+    @Nested
+    @DisplayName("patch 메소드는")
+    class Describe_patch {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 부분 수정한다면")
+        class Context_with_default_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                final Task newTask = new Task();
+                newTask.setTitle("(UPDATED)" + TASK_TITLE);
+                task.setTitle("(UPDATED)" + TASK_TITLE);
+
+                given(service.updateTask(TASK_ID, newTask)).willReturn(task);
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 200 OK 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID))
+                        .andExpect(status().isOk());
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                given(service.updateTask(TASK_ID, task))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                        .andExpect(status().isNotFound());
+            }
+
+        }
+    }
+
+    @Nested
+    @DisplayName("delete 메소드는")
+    class Describe_delete {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 삭제한다면")
+        class Context_with_default_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                given(service.deleteTask(TASK_ID)).willReturn(task);
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 204 NO CONTENT 응답한다")
+            void it_responds_with_204() throws Exception {
+                mockMvc.perform(delete(DEFAULT_PATH + "/" + TASK_ID))
+                        .andExpect(status().isNoContent());
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 삭제한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                given(service.deleteTask(TASK_ID_NOT_EXISTING))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(delete(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                        .andExpect(status().isNotFound());
+            }
+
+        }
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -3,6 +3,7 @@ package com.codesoom.assignment.controllers;
 import com.codesoom.assignment.TaskNotFoundException;
 import com.codesoom.assignment.application.TaskService;
 import com.codesoom.assignment.models.Task;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -149,19 +150,18 @@ class TaskControllerWebTest {
                         .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
             }
 
-            @Test
-            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
-            void it_responds_with_404() throws Exception {
-                Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
-                String content = objectMapper.writeValueAsString(task);
-
-                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(content))
-                        .andExpect(status().isNotFound());
-            }
-
+//            @Test
+//            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+//            void it_responds_with_404() throws Exception {
+//                Task task = new Task();
+//                task.setTitle(TASK_TITLE_UPDATED);
+//                String content = objectMapper.writeValueAsString(task);
+//
+//                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(content))
+//                        .andExpect(status().isNotFound());
+//            }
         }
     }
 
@@ -207,19 +207,18 @@ class TaskControllerWebTest {
                         .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
             }
 
-            @Test
-            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
-            void it_responds_with_404() throws Exception {
-                Task task = new Task();
-                task.setTitle(TASK_TITLE_UPDATED);
-                String content = objectMapper.writeValueAsString(task);
-
-                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(content))
-                        .andExpect(status().isNotFound());
-            }
-
+//            @Test
+//            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+//            void it_responds_with_404() throws Exception {
+//                Task task = new Task();
+//                task.setTitle(TASK_TITLE_UPDATED);
+//                String content = objectMapper.writeValueAsString(task);
+//
+//                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+//                                .contentType(MediaType.APPLICATION_JSON)
+//                                .content(content))
+//                        .andExpect(status().isNotFound());
+//            }
         }
     }
 

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -3,6 +3,7 @@ package com.codesoom.assignment.controllers;
 import com.codesoom.assignment.TaskNotFoundException;
 import com.codesoom.assignment.application.TaskService;
 import com.codesoom.assignment.models.Task;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -22,11 +23,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class TaskControllerWebTest {
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
     @MockBean
     private TaskService service;
 
     private final List<Task> tasks = new LinkedList<>();
     private final String TASK_TITLE = "Test Task";
+    private final String TASK_TITLE_UPDATED = "Updated Task";
     private final Long TASK_ID = 1L;
     private final int FIRST = 0;
     private final Long TASK_ID_NOT_EXISTING = 10L;
@@ -110,8 +114,8 @@ class TaskControllerWebTest {
             void setUp() {
                 final Task task = tasks.get(FIRST);
                 final Task newTask = new Task();
-                newTask.setTitle("(UPDATED)" + TASK_TITLE);
-                task.setTitle("(UPDATED)" + TASK_TITLE);
+                newTask.setTitle(TASK_TITLE_UPDATED);
+                task.setTitle(TASK_TITLE_UPDATED);
 
                 given(service.updateTask(TASK_ID, newTask)).willReturn(task);
             }
@@ -119,7 +123,12 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID))
+                Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+                String content = objectMapper.writeValueAsString(task);
+
+                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID)
+                                .content(content))
                         .andExpect(status().isOk());
             }
         }
@@ -154,8 +163,8 @@ class TaskControllerWebTest {
             void setUp() {
                 final Task task = tasks.get(FIRST);
                 final Task newTask = new Task();
-                newTask.setTitle("(UPDATED)" + TASK_TITLE);
-                task.setTitle("(UPDATED)" + TASK_TITLE);
+                newTask.setTitle(TASK_TITLE_UPDATED);
+                task.setTitle(TASK_TITLE_UPDATED);
 
                 given(service.updateTask(TASK_ID, newTask)).willReturn(task);
             }
@@ -163,7 +172,12 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID))
+                Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+                String content = objectMapper.writeValueAsString(task);
+
+                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID)
+                                .content(content))
                         .andExpect(status().isOk());
             }
         }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -1,0 +1,103 @@
+package com.codesoom.assignment.controllers;
+
+import com.codesoom.assignment.TaskNotFoundException;
+import com.codesoom.assignment.application.TaskService;
+import com.codesoom.assignment.models.Task;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TaskControllerWebTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private TaskService service;
+
+    private final List<Task> tasks = new LinkedList<>();
+    private final String TASK_TITLE = "Test Task";
+    private final Long TASK_ID = 1L;
+    private final int FIRST = 0;
+    private final Long TASK_ID_NOT_EXISTING = 10L;
+    private final String DEFAULT_PATH = "/tasks";
+
+    @BeforeEach
+    void setUp() {
+        Task task = new Task();
+        task.setId(TASK_ID);
+        task.setTitle(TASK_TITLE);
+        tasks.add(task);
+    }
+
+    @AfterEach
+    void clear() {
+        tasks.clear();
+    }
+
+    @Nested
+    @DisplayName("list 메소드는")
+    class Describe_list {
+        @BeforeEach
+        void setUp() {
+            given(service.getTasks()).willReturn(tasks);
+        }
+
+        @Test
+        @DisplayName("HTTP Status Code 200 OK 응답한다")
+        void it_responds_with_200_ok() throws Exception {
+            mockMvc.perform(get(DEFAULT_PATH))
+                    .andExpect(status().isOk());
+        }
+    }
+
+    @Nested
+    @DisplayName("detail 메소드는")
+    class Describe_detail {
+        @Nested
+        @DisplayName("만약 기본 생성된 Task를 상세조회한다면")
+        class Context_with_default_task {
+            @BeforeEach
+            void setUp() {
+                final Task task = tasks.get(FIRST);
+                given(service.getTask(TASK_ID)).willReturn(task);
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 200 OK 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(get(DEFAULT_PATH + "/" + TASK_ID))
+                        .andExpect(status().isOk());
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 상세조회한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                given(service.getTask(TASK_ID_NOT_EXISTING))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_200_ok() throws Exception {
+                mockMvc.perform(get(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                        .andExpect(status().isNotFound());
+            }
+
+        }
+    }
+
+}

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -38,7 +38,6 @@ class TaskControllerWebTest {
     private final Long TASK_ID = 1L;
     private final int FIRST = 0;
     private final Long TASK_ID_NOT_EXISTING = 10L;
-    private final String DEFAULT_PATH = "/tasks";
 
     @BeforeEach
     void setUp() {
@@ -123,11 +122,9 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
-
                 mockMvc.perform(put("/tasks/" + TASK_ID)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(content))
+                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+                                .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk());
             }
         }
@@ -164,11 +161,9 @@ class TaskControllerWebTest {
             @Test
             @DisplayName("HTTP Status Code 200 OK 응답한다")
             void it_responds_with_200_ok() throws Exception {
-                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
-
                 mockMvc.perform(patch("/tasks/" + TASK_ID)
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(content))
+                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+                                .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isOk());
             }
         }
@@ -234,15 +229,13 @@ class TaskControllerWebTest {
     @Nested
     @DisplayName("create 메소드는")
     class Describe_create {
-            @Test
-            @DisplayName("HTTP Status Code 201 CREATED 응답한다")
-            void it_responds_with_201() throws Exception {
-                String content = objectMapper.writeValueAsString(new Task(TASK_TITLE_UPDATED));
-
-                mockMvc.perform(post("/tasks")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(content))
-                        .andExpect(status().isCreated());
-            }
+        @Test
+        @DisplayName("HTTP Status Code 201 CREATED 응답한다")
+        void it_responds_with_201() throws Exception {
+            mockMvc.perform(post("/tasks")
+                            .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isCreated());
         }
+    }
 }

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.LinkedList;
@@ -128,6 +129,7 @@ class TaskControllerWebTest {
                 String content = objectMapper.writeValueAsString(task);
 
                 mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
                                 .content(content))
                         .andExpect(status().isOk());
             }
@@ -139,14 +141,24 @@ class TaskControllerWebTest {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
-                given(service.updateTask(TASK_ID, task))
+                final Task newTask = new Task();
+                newTask.setTitle(TASK_TITLE_UPDATED);
+                task.setTitle(TASK_TITLE_UPDATED);
+
+                given(service.updateTask(TASK_ID_NOT_EXISTING, newTask))
                         .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
             }
 
             @Test
             @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
             void it_responds_with_404() throws Exception {
-                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+                String content = objectMapper.writeValueAsString(task);
+
+                mockMvc.perform(put(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(content))
                         .andExpect(status().isNotFound());
             }
 
@@ -177,6 +189,7 @@ class TaskControllerWebTest {
                 String content = objectMapper.writeValueAsString(task);
 
                 mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID)
+                                .contentType(MediaType.APPLICATION_JSON)
                                 .content(content))
                         .andExpect(status().isOk());
             }
@@ -187,15 +200,23 @@ class TaskControllerWebTest {
         class Context_without_existing_task {
             @BeforeEach
             void setUp() {
-                final Task task = tasks.get(FIRST);
-                given(service.updateTask(TASK_ID, task))
+                final Task newTask = new Task();
+                newTask.setTitle(TASK_TITLE_UPDATED);
+
+                given(service.updateTask(TASK_ID_NOT_EXISTING, newTask))
                         .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
             }
 
             @Test
             @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
             void it_responds_with_404() throws Exception {
-                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING))
+                Task task = new Task();
+                task.setTitle(TASK_TITLE_UPDATED);
+                String content = objectMapper.writeValueAsString(task);
+
+                mockMvc.perform(patch(DEFAULT_PATH + "/" + TASK_ID_NOT_EXISTING)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(content))
                         .andExpect(status().isNotFound());
             }
 

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -129,19 +129,25 @@ class TaskControllerWebTest {
             }
         }
 
-//        @Nested
-//        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
-//        class Context_without_existing_task {
-//            @Test
-//            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
-//            void it_responds_with_404() throws Exception {
-//                mockMvc.perform(put("/tasks/" + TASK_ID_NOT_EXISTING)
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
-//                                .accept(MediaType.APPLICATION_JSON))
-//                        .andExpect(status().isNotFound());
-//            }
-//        }
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 수정한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                given(service.updateTask(eq(TASK_ID_NOT_EXISTING), any(Task.class)))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(put("/tasks/" + TASK_ID_NOT_EXISTING)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isNotFound());
+            }
+        }
     }
 
     @Nested
@@ -168,19 +174,24 @@ class TaskControllerWebTest {
             }
         }
 
-//        @Nested
-//        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
-//        class Context_without_existing_task {
-//            @Test
-//            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
-//            void it_responds_with_404() throws Exception {
-//                mockMvc.perform(patch("/tasks/" + TASK_ID_NOT_EXISTING)
-//                                .contentType(MediaType.APPLICATION_JSON)
-//                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
-//                                .accept(MediaType.APPLICATION_JSON))
-//                        .andExpect(status().isNotFound());
-//            }
-//        }
+        @Nested
+        @DisplayName("만약 존재하지 않는 Task를 부분 수정한다면")
+        class Context_without_existing_task {
+            @BeforeEach
+            void setUp() {
+                given(service.updateTask(eq(TASK_ID_NOT_EXISTING), any(Task.class)))
+                        .willThrow(new TaskNotFoundException(TASK_ID_NOT_EXISTING));
+            }
+
+            @Test
+            @DisplayName("HTTP Status Code 404 NOT FOUND 응답한다")
+            void it_responds_with_404() throws Exception {
+                mockMvc.perform(patch("/tasks/" + TASK_ID_NOT_EXISTING)
+                                .content(taskToJson(new Task(TASK_TITLE_UPDATED)))
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isNotFound());
+            }
+        }
     }
 
     @Nested

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -236,6 +236,11 @@ class TaskControllerWebTest {
     @Nested
     @DisplayName("create 메소드는")
     class Describe_create {
+        @BeforeEach
+        void setUp() {
+            given(service.createTask(any(Task.class))).willReturn(any(Task.class));
+        }
+
         @Test
         @DisplayName("HTTP Status Code 201 CREATED 응답한다")
         void it_responds_with_201() throws Exception {

--- a/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/TaskControllerWebTest.java
@@ -71,8 +71,8 @@ class TaskControllerWebTest {
     @DisplayName("detail 메소드는")
     class Describe_detail {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 상세조회한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 상세조회한다면")
+        class Context_with_existing_task {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
@@ -110,8 +110,8 @@ class TaskControllerWebTest {
     @DisplayName("update 메소드는")
     class Describe_update {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 수정한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 수정한다면")
+        class Context_with_existing_task {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
@@ -169,8 +169,8 @@ class TaskControllerWebTest {
     @DisplayName("patch 메소드는")
     class Describe_patch {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 부분 수정한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 부분 수정한다면")
+        class Context_with_existing_task {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);
@@ -226,8 +226,8 @@ class TaskControllerWebTest {
     @DisplayName("delete 메소드는")
     class Describe_delete {
         @Nested
-        @DisplayName("만약 기본 생성된 Task를 삭제한다면")
-        class Context_with_default_task {
+        @DisplayName("만약 존재하는 Task를 삭제한다면")
+        class Context_with_existing_task {
             @BeforeEach
             void setUp() {
                 final Task task = tasks.get(FIRST);

--- a/app/src/test/java/com/codesoom/assignment/models/TaskTest.java
+++ b/app/src/test/java/com/codesoom/assignment/models/TaskTest.java
@@ -1,0 +1,55 @@
+package com.codesoom.assignment.models;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskTest {
+    private Task task;
+    private final String TASK_TITLE = "Test Task";
+    private final String TASK_TITLE_UPDATED = "Updated Task";
+    private final Long TASK_ID = 1L;
+    private final Long TASK_ID_UPDATED = 10L;
+    @BeforeEach
+    void setUp() {
+        task = new Task(TASK_ID, TASK_TITLE);
+    }
+
+    @Test
+    @DisplayName("기본 생성된 Task가 존재하면, getId 요청하면 기본 생성 Task의 id와 같은 값을 반환해야 한다")
+    void getId() {
+        final Long actual = task.getId();
+
+        assertThat(actual).isEqualTo(TASK_ID);
+    }
+
+    @Test
+    @DisplayName("기본 생성된 Task에 새로운 Id값을 setId로 요청하면 getId 요청에 따라 새로운 Id값을 반환해야 한다")
+    void setId() {
+        task.setId(TASK_ID_UPDATED);
+        final Long actual = task.getId();
+
+        assertThat(actual).isEqualTo(TASK_ID_UPDATED);
+    }
+
+    @Test
+    @DisplayName("기본 생성된 Task가 존재하면, gettitle 요청하면 기본 생성 Task의 title와 같은 값을 반환해야 한다")
+    void getTitle() {
+        final String actual = task.getTitle();
+
+        assertThat(actual).isEqualTo(TASK_TITLE);
+    }
+
+    @Test
+    @DisplayName("기본 생성된 Task에 새로운 Title을 setTitle로 요청하면 getTitle 요청에 따라 새로운 Title값을 반환해야 한다")
+    void setTitle() {
+        task.setTitle(TASK_TITLE_UPDATED);
+        final String actual = task.getTitle();
+
+        assertThat(actual).isEqualTo(TASK_TITLE_UPDATED);
+    }
+}


### PR DESCRIPTION
안녕하세요 맥스웰입니다!

Todo List API에서 필요한 테스트 케이스에 대해 목록화하는 작업을 했습니다. 

private 메소드에 대해서는 테스트에서 제외했습니다. private 메소드는 객체 간 협력의 대상이 아니고, 동시에 내부적으로 쉽게 변경될 수 있는 부분이기 때문에 테스트라는 비용 대비 이익이 적다고 판단했습니다.

코드숨에서 제일 기대가 되는 과정인 테스트가 드디어 시작이네요!

최선을 다해보겠습니다.

## 1. Controller 테스트 케이스 목록

### 가. **‘GET /tasks’ 요청처리**
- [x]  해당 요청을 정상 처리 후 응답 시 HTTP 상태코드 200이 되어야 한다
- [x]  Task 객체가 없다면, 해당 요청 수신 시 Response Body에 빈 배열의 형태로 응답해야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 수는 Task 객체의 수와 같아야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 속성값은 Task 엔티티 객체의 속성값과 모두 일치해야 한다

### 나. **‘GET /tasks/{id}’ 요청처리**
- [x]  해당 요청을 정상 처리 후 응답 시 HTTP 상태코드는 200이 되어야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 속성값은 Task 엔티티 객체의 속성값과 모두 일치해야 한다
- [x]  request param으로 전달한 id에 맞는 Task 엔티티 객체가 없다면, HTTP 상태코드는 404가 되어야 한다

### 다. **‘POST /tasks/’ 요청처리**
- [x] 해당 요청을 정상 처리 후 응답 시 HTTP 상태코드는 201이 되어야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 속성값은 Task 엔티티 객체의 속성값과 모두 일치해야 한다

### 라. **‘PATCH /tasks/{id}’ 요청처리**
- [x]  해당 요청을 정상 처리 후 응답 시 HTTP 상태코드는 200이 되어야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 속성값은 Task 엔티티 객체의 속성값과 모두 일치해야 한다
- [x]  request param으로 전달한 id에 맞는 Task 엔티티 객체가 없다면, HTTP 상태코드는 404가 되어야 한다

### 마. **‘PATCH /tasks/{id}’ 요청처리**
- [x]  해당 요청을 정상 처리 후 응답 시 HTTP 상태코드는 200이 되어야 한다
- [x]  해당 요청에 따른 응답 시 Response Body에 담긴 JSON 객체의 속성값은 Task 엔티티 객체의 속성값과 모두 일치해야 한다
- [x]  request param으로 전달한 id에 맞는 Task 엔티티 객체가 없다면, HTTP 상태코드는 404가 되어야 한다

### 바. **‘DELETE /tasks/{id}’ 요청처리**

- [x]  해당 요청에 따른 응답 시 path parm으로 전달한 값에 해당되는 Task 객체를 처리 후 Response Body에 빈값을 전달해야 한다
- [x]  해당 요청을 정상 처리 후 응답 시 HTTP 상태코드는 204가 되어야 한다
- [x]  request param으로 전달한 id에 맞는 Task 엔티티 객체가 없다면, HTTP 상태코드는 404가 되어야 한다

## 2. Service 테스트 케이스 목록

### 가. 모든 Task 조회

- [x]  Task 엔티티를 모두 조회한 결과, 조회 결과의 Task 엔티티 개수와 Task 엔티티를 저장하고 있는 저장소에 있는 Task 엔티티의 개수는 같아야 한다
- [x]  Task 엔티티를 모두 조회한 결과, 조회 결과의 Task 엔티티의 필드와 저장소의 Task 엔티티의 필드는 모두 같아야 한다

### 나. Task 생성

- [x]  생성된 Task의 title은 매개변수로 전달된 Task source의 title과 같아야 한다
- [x]  생성된 Task의 id는 null이 아니어야 한다

### 다. 특정 Task 조회

- [x]  메소드 호출 시 사용한 id와 조회 결과의 Task의 id는 같아야 한다
- [x]  Task의 id 해당하는 Task가 없을 경우 `TaskNotFoundException` 예외가 발생해야 한다

### 라. 특정 Task 수정

- [x]  메소드 호출 시 매개변수로 전달한 id와 응답으로 전달된 Task의 id는 같아야 한다
- [x]  메소드 호출 시 매개변수로 전달한 Task의 title과 응답으로 전달된 Task의 title은 같아야 한다
- [x]  Task 엔티티의 아이디에 해당하는 Task가 없을 경우 `TaskNotFoundException` 예외가 발생해야 한다

### 마. 특정 Task 삭제

- [x]  메소드 호출 시 Task의 id에 해당하는 Task가 없을 경우 `TaskNotFoundException` 예외가 발생해야 한다
- [x]  Task 삭제 메소드 호출 이후 매개변수로 전달한 id로 Task 조회 시 `TaskNotFoundException` 예외가 발생해야 한다

## 3. Model 테스트 케이스 목록

### 가. id 반환

- [x]  Task의 id와 메소드 호출에 따라 반환된 id는 같아야 한다

### 나. title 반환

- [x]  Task의 title와 메소드 호출에 따라 반환된 title는 같아야 한다

### 다. id 수정

- [x]  메소드 호출 시 매개변수로 전달한 id와 Task의 id는 같아야 한다

### 라. title 수정

- [x]  메소드 호출 시 매개변수로 전달한 title과 Task의 title은 같아야 한다